### PR TITLE
refactor: fp utils

### DIFF
--- a/src/fp.spec.ts
+++ b/src/fp.spec.ts
@@ -1,0 +1,51 @@
+import { curry, filter, map, pipe, prop } from "./fp";
+
+describe("pipe", () => {
+  it("should dasiy chain unary functions together", () => {
+    const chain = pipe(
+      (a) => a + 1,
+      (a) => a * 2
+    );
+
+    const result = chain(10);
+
+    expect(result).toEqual(22);
+  });
+});
+
+describe("curry", () => {
+  it("should allow partial application to a function", () => {
+    const foo = curry((a, b) => a + b);
+    const partiallyApplied = foo(1);
+    const result = partiallyApplied(10);
+
+    expect(result).toEqual(11);
+  });
+});
+
+describe("prop", () => {
+  it("should return the property from an object", () => {
+    const obj = {
+      name: "Foo",
+    };
+    const name = prop("name");
+    const result = name(obj);
+    expect(result).toEqual("Foo");
+  });
+});
+
+describe("map", () => {
+  it("should apply a map function to a list", () => {
+    const intsToString = map((a) => a.toString());
+    const result = intsToString([1, 2, 3]);
+    expect(result).toEqual(["1", "2", "3"]);
+  });
+});
+
+describe("filter", () => {
+  it("should apply a filter function to a list", () => {
+    const graterThanTwo = filter((a) => a > 2);
+    const result = graterThanTwo([1, 2, 3]);
+    expect(result).toEqual([3]);
+  });
+});

--- a/src/fp.ts
+++ b/src/fp.ts
@@ -15,6 +15,14 @@ export const curry = (func) => {
   return curried;
 };
 
-// prop
-// map
-// filter
+export const prop = curry((property, object) => {
+  return object[property];
+});
+
+export const map = curry((fn, arr) => {
+  return arr.map(fn);
+});
+
+export const filter = curry((fn, arr) => {
+  return arr.filter(fn);
+});

--- a/src/match.ts
+++ b/src/match.ts
@@ -1,4 +1,4 @@
-import { curry, pipe } from "./fp";
+import { curry, map, pipe } from "./fp";
 import { tokenise } from "./nlp";
 
 const matchPropertyValue = curry((property, value, object) => {
@@ -27,9 +27,7 @@ const termToMatchFn = (term) => {
   return matchDefault(term);
 };
 
-const termsToMatchFns = (terms) => {
-  return terms.map(termToMatchFn);
-};
+const termsToMatchFns = map(termToMatchFn);
 
 const applyMatchers = curry((matcherFns, object) =>
   matcherFns.map((matcher) => matcher(object)).includes(true)

--- a/src/object.spec.ts
+++ b/src/object.spec.ts
@@ -76,4 +76,14 @@ describe("normaliseObject", () => {
 
     expect(result).toEqual({ a: "foo,bar" });
   });
+  it("should ignore null or undefined values", () => {
+    const mockObject = {
+      a: "foo",
+      b: null,
+      c: undefined,
+    };
+    const result = normaliseObject(mockObject);
+
+    expect(result).toEqual({ a: "foo" });
+  });
 });

--- a/src/object.ts
+++ b/src/object.ts
@@ -9,6 +9,9 @@ export const normaliseObject = (obj) => {
   const keyValuePairs = Object.entries(obj);
   return keyValuePairs.reduce((accumulator, pair) => {
     const [key, value] = pair;
+    if (value === undefined || value === null) {
+      return accumulator;
+    }
     if (isArray(value)) {
       accumulator[normaliseString(key)] = stringifyArray(value);
       return accumulator;

--- a/src/sugar.ts
+++ b/src/sugar.ts
@@ -1,11 +1,15 @@
 import { normaliseObject } from "./object";
 import { makeMatcherFrom } from "./match";
+import { curry, filter, map, pipe, prop } from "./fp";
 
-export const sugarFilter = (haystack, input) => {
+const id = prop("id");
+const toDecimal = (a: string): number => parseInt(a, 10);
+const idToDecimal = pipe(id, toDecimal);
+const objectPipeline = (match) =>
+  pipe(map(normaliseObject), filter(match), map(idToDecimal));
+
+export const sugarFilter = curry((haystack, input) => {
   const onMatch = makeMatcherFrom(input);
-  const results = haystack
-    .map(normaliseObject)
-    .filter(onMatch)
-    .map((flag) => parseInt(flag.id, 10)); // collect matched IDs
-  return haystack.filter((flag) => results.includes(flag.id));
-};
+  const results = objectPipeline(onMatch)(haystack); // collect matched IDs
+  return haystack.filter((obj) => results.includes(obj.id));
+});


### PR DESCRIPTION
This is a refactor around the FP utils. Allows for greater composition.

* Adding a composable `map` and `filter` variant
* Adding a composable object `prop` function
* Increasing the testing around FP utils
* Also fixes a bug where null or undefined values were attempted to be searched on